### PR TITLE
Add module for validating UNSPSC numbers #2

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,1 @@
+continue

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,1 +1,0 @@
-continue

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'httparty'
+gem 'nokogiri'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (10.0.2)
     diff-lcs (1.3)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
@@ -34,7 +33,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.13)
-  byebug
   gtin_extras!
   httparty
   nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (10.0.2)
     diff-lcs (1.3)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
+    mini_portile2 (2.3.0)
+    multi_xml (0.6.0)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -27,9 +34,12 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.13)
+  byebug
   gtin_extras!
+  httparty
+  nokogiri
   rake (~> 10.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gtin_extras
-Ruby String extensions for validating and formatting GTIN/UPC/EAN/GS1 _and_ PLU _and_ ASIN _and_ ISBN numbers. Use these to clean up and validate your ecommerce data!
+Ruby String extensions for validating and formatting GTIN/UPC/EAN/GS1 _and_ PLU _and_ ASIN _and_ ISBN _and_ UNSPSC numbers. Use these to clean up and validate your ecommerce data!
 
 ## Usage
 
@@ -19,6 +19,12 @@ require 'gtin_extras'
 '960-425-059-0'.isbn?           # true
 '960 425 059 0'.isbn?           # true
 '9781234567897'.isbn?           # true
+'43201501'.unspsc?              # true
+'4320150114'.unspsc?            # false
+'43201501'.unspsc_title?        #'Asynchronous transfer mode ATM telecommunications interface cards'
+'43201511'.unspsc_title?        # 'No results found'
+
+
 ```
 
 ## Installation
@@ -61,6 +67,9 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 - https://www.ifpsglobal.com/Identification/PLU-Codes
 - https://www.instructables.com/id/How-to-verify-a-ISBN/
 - https://en.wikipedia.org/wiki/International_Standard_Book_Number
+- 
+https://www.unspsc.org/search-code/, https://www.unspsc.org/faqs
+- 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ require 'gtin_extras'
 '9781234567897'.isbn?           # true
 '43201501'.unspsc?              # true
 '4320150114'.unspsc?            # false
-'43201501'.unspsc_title?        #'Asynchronous transfer mode ATM telecommunications interface cards'
+'43201501'.unspsc_title?        # 'Asynchronous transfer mode ATM telecommunications interface cards'
 '43201511'.unspsc_title?        # 'No results found'
 
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 - https://www.instructables.com/id/How-to-verify-a-ISBN/
 - https://en.wikipedia.org/wiki/International_Standard_Book_Number
 - https://www.unspsc.org/search-code/
+
 - https://www.unspsc.org/faqs
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 - https://www.ifpsglobal.com/Identification/PLU-Codes
 - https://www.instructables.com/id/How-to-verify-a-ISBN/
 - https://en.wikipedia.org/wiki/International_Standard_Book_Number
-- 
-https://www.unspsc.org/search-code/, https://www.unspsc.org/faqs
-- 
+- https://www.unspsc.org/search-code/
+- https://www.unspsc.org/faqs
 
 ## Contributing
 

--- a/lib/gtin_extras.rb
+++ b/lib/gtin_extras.rb
@@ -4,4 +4,5 @@ module GTINExtras
   require 'gtin_extras/asin'
   require 'gtin_extras/plu'
   require 'gtin_extras/isbn'
+  require 'gtin_extras/unspsc'
 end

--- a/lib/gtin_extras/unspsc.rb
+++ b/lib/gtin_extras/unspsc.rb
@@ -33,7 +33,7 @@ module UNSPSC
       )
   end
 
-  # Using uspsc_title, determines if unspsc code is valid 
+  # Using unspsc_title, determines if unspsc code is valid 
   def unspsc?
     data = unspsc_title?()
     if (data == 'API call failed')

--- a/lib/gtin_extras/unspsc.rb
+++ b/lib/gtin_extras/unspsc.rb
@@ -17,13 +17,15 @@ module UNSPSC
     puts ('API call failed')
   end
 
-  # Parses html, gets text from last td element 
+  # Checks input length, parses html, gets text from last td element 
   def unspsc_title?
+    return 'No results found' unless to_str.length == 8
     unparsed_page = scrape_data()
     unparsed_page != nil ? (
       parsed_page = Nokogiri::HTML(unparsed_page)
       td_elements = parsed_page.css('td')
       title = td_elements.last.children.children.text 
+      # indicates empty td element
       return title unless title.include? "\r"
       return 'No results found'
     ) : (

--- a/lib/gtin_extras/unspsc.rb
+++ b/lib/gtin_extras/unspsc.rb
@@ -1,0 +1,49 @@
+# String validation for UNSPSC codes
+# NOTES 
+#     - Requires internet connection to run, will fail with message 'API call failed' if HTTParty get request fails for any reason
+#     - Limited to verifying 8 digit UNSPSC. Will not accept optional 2 digit 'Business Function' suffix
+#     - Module will need to be updated if unspsc.org website is updated
+# Refs: https://www.unspsc.org/search-code/, http://www.unspsc.org/faqs
+
+require 'httparty'
+require 'nokogiri'
+
+module UNSPSC
+  # Gets raw html from unspsc.org. If get request fails, passes error message. 
+  def scrape_data
+    unparsed_page = HTTParty.get("https://www.unspsc.org/search-code/default.aspx?CSS=#{to_s}")
+    return unparsed_page
+  rescue HTTParty::Error, SocketError => e
+    puts ('API call failed')
+  end
+
+  # Parses html, gets text from last td element 
+  def unspsc_title?
+    unparsed_page = scrape_data()
+    unparsed_page != nil ? (
+      parsed_page = Nokogiri::HTML(unparsed_page)
+      td_elements = parsed_page.css('td')
+      title = td_elements.last.children.children.text 
+      return title unless title.include? "\r"
+      return 'No results found'
+    ) : (
+      return 'API call failed'
+      )
+  end
+
+  # Using uspsc_title, determines if unspsc code is valid 
+  def unspsc?
+    data = unspsc_title?()
+    if (data == 'API call failed')
+      return 'API call failed'
+    elsif (data == 'No results found')
+      return false
+    end
+    return true
+  end
+end
+
+# Extend String with these methods
+class String
+  include UNSPSC
+end

--- a/lib/gtin_extras/version.rb
+++ b/lib/gtin_extras/version.rb
@@ -1,3 +1,3 @@
 module GTINExtras
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/gtin_extras_spec.rb
+++ b/spec/gtin_extras_spec.rb
@@ -160,6 +160,9 @@ describe UNSPSC do
     it 'rejects bad UNSPSC' do
       expect('49240001'.unspsc?).to be false
     end
+    it 'only accepts 8 digit numbers' do
+      expect('4924'.unspsc?).to be false
+    end
     it 'does not validate 10 digit UNSPSC' do
       expect('4320150114'.unspsc?).to be false
     end
@@ -174,6 +177,7 @@ describe UNSPSC do
     end
     it 'Returns "No results found" for bad UNSPSC code' do
       expect('49240001'.unspsc_title?).to eq 'No results found'
+      expect('4924'.unspsc_title?).to eq 'No results found'
     end
   end
 end

--- a/spec/gtin_extras_spec.rb
+++ b/spec/gtin_extras_spec.rb
@@ -119,7 +119,7 @@ describe PLU do
 end
 
 describe ISBN do
-  describe '#isbn' do
+  describe '#isbn?' do
     it 'rejects words' do
       expect('foobar'.isbn?).to be false
     end
@@ -145,6 +145,35 @@ describe ISBN do
     it 'validates ISBN with hyphens, spaces, or other characters' do
       expect('960-425-059-0'.isbn?).to be true
       expect('ISBN 978 0 393 34340 3'.isbn?).to be true
+    end
+  end
+end
+
+describe UNSPSC do 
+  describe '#unspsc?' do 
+    it 'rejects words' do
+      expect('foobar'.unspsc?).to be false
+    end
+    it 'rejects words and numbers' do
+      expect('123foobar'.unspsc?).to be false
+    end
+    it 'rejects bad UNSPSC' do
+      expect('49240001'.unspsc?).to be false
+    end
+    it 'does not validate 10 digit UNSPSC' do
+      expect('4320150114'.unspsc?).to be false
+    end
+    it 'validates 8 digit UNSPSC' do
+      expect('43201501'.unspsc?).to be true
+    end
+  end
+  describe '#unspsc_title?' do
+    it 'Returns the title of a valid UNSPSC code' do
+      expect('49240000'.unspsc_title?).to eq 'Recreation and playground and swimming and spa equipment and supplies'
+      expect('43201501'.unspsc_title?).to eq 'Asynchronous transfer mode ATM telecommunications interface cards'
+    end
+    it 'Returns "No results found" for bad UNSPSC code' do
+      expect('49240001'.unspsc_title?).to eq 'No results found'
     end
   end
 end


### PR DESCRIPTION
Issue #2 

This is a scraper program - it will make a get request to https://www.unspsc.org/search-code, and return a value based on parsed html fetched from that request. 

It contains two methods - one returning a boolean to verify a user submitted UNSPSC code is valid, the other which will return the 'title' of the UNSPSC code as a string (See https://www.unspsc.org/search-code/default.aspx?CSS=43201510 for an example). 

This solution does break from convention from the rest of the gtin_extras program, as it uses outside libraries (HTTParty & Nokogiri), relies on an http request, and relies on stasis of unspsc.org html to run properly. However, I believe this to be a valid way to verify UNSPSC without a membership, as UNSPSC codes seem not to follow any mathematical pattern.

Sidenote - I think it would be worth double-checking my error handling, as I'm not as familiar with best practices for ruby.
